### PR TITLE
Persist test flow run snapshots to localStorage

### DIFF
--- a/src/lib/components/test-flows/TestFlowEditor.svelte
+++ b/src/lib/components/test-flows/TestFlowEditor.svelte
@@ -23,6 +23,11 @@
   import type { TemplateContext } from '$lib/template/types';
   import { buildTemplatePreviewContext, type TemplatePreviewContext } from '$lib/template/preview';
   import { projectStore } from '$lib/store/project';
+  import {
+    clearRunSnapshot,
+    loadRunSnapshot,
+    saveRunSnapshot
+  } from '$lib/store/test-flow-run-cache';
   import * as stepManagement from './step-management';
   import {
     FlowRunner,
@@ -270,6 +275,32 @@
     dispatch('log', { level, message, details });
   }
 
+  function hydrateCachedRunSnapshot(): void {
+    if (!flowRunner || isRunning) return;
+
+    const snapshot = loadRunSnapshot(testFlowId, flowData);
+    if (!snapshot) return;
+
+    flowRunner.hydrateExecutionSnapshot(snapshot.executionState, snapshot.parameterValues);
+    currentParameterValues = snapshot.parameterValues;
+    currentStep = snapshot.executionState.currentStep || 0;
+    progress = snapshot.executionState.progress || 0;
+    outputResults = snapshot.flowOutputs;
+    outputExecutionError = null;
+  }
+
+  function persistSuccessfulRunSnapshot(flowOutputs: Record<string, unknown>): void {
+    if (!flowRunner) return;
+
+    saveRunSnapshot({
+      testFlowId,
+      flowData,
+      executionState: flowRunner.executionState,
+      parameterValues: flowRunner.parameterValues,
+      flowOutputs
+    });
+  }
+
   function initializeFlowRunner() {
     const options: FlowRunnerOptions = {
       flowData,
@@ -306,6 +337,10 @@
           outputExecutionError = data.error;
         }
 
+        if (data.success) {
+          persistSuccessfulRunSnapshot(data.flowOutputs || {});
+        }
+
         // Force an update of all components that depend on the execution state
         executionStore.update((state) => ({ ...state }));
 
@@ -314,6 +349,7 @@
     };
 
     flowRunner = new FlowRunner(options);
+    hydrateCachedRunSnapshot();
 
     // Store current environment variables for comparison
     previousEnvironmentVariables = { ...environmentVariables };
@@ -419,6 +455,8 @@
       showParameterInputModal = false;
       pendingSingleStepExecution = null;
     }
+
+    clearRunSnapshot(testFlowId);
 
     // Reset the execution state store
     executionStore.set({});

--- a/src/lib/flow-runner/flow-runner.ts
+++ b/src/lib/flow-runner/flow-runner.ts
@@ -1,6 +1,15 @@
-import type { TestFlowData, FlowStep, FlowParameter, ExecutionState } from '$lib/components/test-flows/types';
+import type {
+  TestFlowData,
+  FlowStep,
+  FlowParameter,
+  ExecutionState
+} from '$lib/components/test-flows/types';
 import type { RequestCookie } from '$lib/http_client/test-flow';
-import { FlowExecutionEngine, type ExecutionPreferences, type ExecutionContext } from './execution-engine';
+import {
+  FlowExecutionEngine,
+  type ExecutionPreferences,
+  type ExecutionContext
+} from './execution-engine';
 import { ParameterManager, type ParameterManagerContext } from './parameter-manager';
 import { FlowOutputEvaluator, type OutputEvaluatorContext } from './output-evaluator';
 import { FlowValidator } from './validator';
@@ -13,14 +22,21 @@ export interface FlowRunnerOptions {
   onLog: (level: 'info' | 'debug' | 'error' | 'warning', message: string, details?: string) => void;
   onExecutionStateUpdate: (state: ExecutionState) => void;
   onEndpointStateUpdate: (data: { endpointId: string; state: any }) => void;
-  onStepExecutionComplete?: (data: { stepId: string; stepIndex?: number; success: boolean; error?: unknown }) => void;
+  onStepExecutionComplete?: (data: {
+    stepId: string;
+    stepIndex?: number;
+    success: boolean;
+    error?: unknown;
+  }) => void;
   onExecutionStart?: () => void;
-  onExecutionComplete?: (data: { 
-    success: boolean; 
-    error?: unknown; 
-    storedResponses: Record<string, unknown>; 
-    parameterValues: Record<string, unknown>; 
-    flowOutputs: Record<string, unknown> 
+  onExecutionComplete?: (data: {
+    success: boolean;
+    error?: unknown;
+    storedResponses: Record<string, unknown>;
+    storedTransformations: Record<string, Record<string, unknown>>;
+    executionState: ExecutionState;
+    parameterValues: Record<string, unknown>;
+    flowOutputs: Record<string, unknown>;
   }) => void;
 }
 
@@ -89,10 +105,18 @@ export class FlowRunner {
       environmentVariables: this.options.environmentVariables,
       cookieStore: this.state.cookieStore,
       selectedEnvironment: this.options.selectedEnvironment,
-      get shouldStopExecution() { return state.shouldStopExecution; },
-      set shouldStopExecution(value) { state.shouldStopExecution = value; },
-      get error() { return state.error; },
-      set error(value) { state.error = value; },
+      get shouldStopExecution() {
+        return state.shouldStopExecution;
+      },
+      set shouldStopExecution(value) {
+        state.shouldStopExecution = value;
+      },
+      get error() {
+        return state.error;
+      },
+      set error(value) {
+        state.error = value;
+      },
       executionState: this.state.executionState,
       addLog: this.options.onLog,
       updateExecutionState: this.updateExecutionState.bind(this)
@@ -112,7 +136,11 @@ export class FlowRunner {
     this.outputEvaluator = new FlowOutputEvaluator(outputContext);
   }
 
-  async runFlow(): Promise<{ success: boolean; error?: unknown; parametersWithMissingValues?: FlowParameter[] }> {
+  async runFlow(): Promise<{
+    success: boolean;
+    error?: unknown;
+    parametersWithMissingValues?: FlowParameter[];
+  }> {
     this.resetExecution();
 
     const validationError = FlowValidator.getValidationErrorMessage(this.options.flowData);
@@ -122,6 +150,8 @@ export class FlowRunner {
         success: false,
         error: this.state.error,
         storedResponses: this.state.storedResponses,
+        storedTransformations: this.state.storedTransformations,
+        executionState: this.state.executionState,
         parameterValues: this.state.parameterValues,
         flowOutputs: {}
       });
@@ -130,15 +160,20 @@ export class FlowRunner {
 
     // Prepare parameters
     this.state.parameterValues = this.parameterManager.prepareParameters();
-    
+
     // Update execution context with new parameter values
     this.executionEngine.updateParameterValues(this.state.parameterValues);
-    
-    const parametersWithMissingValues = this.parameterManager.checkRequiredParameters(this.state.parameterValues);
+
+    const parametersWithMissingValues = this.parameterManager.checkRequiredParameters(
+      this.state.parameterValues
+    );
 
     if (parametersWithMissingValues.length > 0) {
-      this.options.onLog('info', 'Required parameters need input', 
-        `${parametersWithMissingValues.length} required Parameter(s) need values`);
+      this.options.onLog(
+        'info',
+        'Required parameters need input',
+        `${parametersWithMissingValues.length} required Parameter(s) need values`
+      );
       return { success: false, parametersWithMissingValues };
     }
 
@@ -169,7 +204,7 @@ export class FlowRunner {
       }
 
       this.state.progress = 100;
-      
+
       let flowOutputs: Record<string, unknown> = {};
       if (!this.state.error) {
         flowOutputs = this.outputEvaluator.evaluateOutputs();
@@ -179,20 +214,27 @@ export class FlowRunner {
         success: !this.state.error,
         error: this.state.error,
         storedResponses: this.state.storedResponses,
+        storedTransformations: this.state.storedTransformations,
+        executionState: this.state.executionState,
         parameterValues: this.state.parameterValues,
         flowOutputs
       });
 
       return { success: !this.state.error, error: this.state.error };
-
     } catch (err: unknown) {
       this.state.error = err;
-      this.options.onLog('error', 'Flow execution error', err instanceof Error ? err.message : String(err));
-      
+      this.options.onLog(
+        'error',
+        'Flow execution error',
+        err instanceof Error ? err.message : String(err)
+      );
+
       this.options.onExecutionComplete?.({
         success: false,
         error: this.state.error,
         storedResponses: this.state.storedResponses,
+        storedTransformations: this.state.storedTransformations,
+        executionState: this.state.executionState,
         parameterValues: this.state.parameterValues,
         flowOutputs: {}
       });
@@ -203,7 +245,10 @@ export class FlowRunner {
     }
   }
 
-  async executeSingleStep(step: FlowStep, stepIndex?: number): Promise<{ success: boolean; error?: unknown; parametersWithMissingValues?: FlowParameter[] }> {
+  async executeSingleStep(
+    step: FlowStep,
+    stepIndex?: number
+  ): Promise<{ success: boolean; error?: unknown; parametersWithMissingValues?: FlowParameter[] }> {
     if (!step || !step.step_id) {
       const error = new Error('Invalid step provided for execution');
       return { success: false, error };
@@ -221,15 +266,20 @@ export class FlowRunner {
       this.state.parameterValues = this.parameterManager.prepareParameters();
       this.options.onLog('debug', 'Parameters prepared for single step execution');
     }
-    
+
     // Update execution engine with parameter values
     this.executionEngine.updateParameterValues(this.state.parameterValues);
-    
+
     // Check for required parameters
-    const parametersWithMissingValues = this.parameterManager.checkRequiredParameters(this.state.parameterValues);
+    const parametersWithMissingValues = this.parameterManager.checkRequiredParameters(
+      this.state.parameterValues
+    );
     if (parametersWithMissingValues.length > 0) {
-      this.options.onLog('info', 'Required parameters need input', 
-        `${parametersWithMissingValues.length} required parameter(s) need values: ${parametersWithMissingValues.map(p => p.name).join(', ')}`);
+      this.options.onLog(
+        'info',
+        'Required parameters need input',
+        `${parametersWithMissingValues.length} required parameter(s) need values: ${parametersWithMissingValues.map((p) => p.name).join(', ')}`
+      );
       return { success: false, parametersWithMissingValues };
     }
 
@@ -240,7 +290,11 @@ export class FlowRunner {
     this.state.isRunning = true;
 
     try {
-      this.options.onLog('info', `Executing step ${step.step_id} individually`, JSON.stringify(step));
+      this.options.onLog(
+        'info',
+        `Executing step ${step.step_id} individually`,
+        JSON.stringify(step)
+      );
       await this.executionEngine.executeStep(step);
 
       this.options.onStepExecutionComplete?.({
@@ -251,7 +305,11 @@ export class FlowRunner {
 
       return { success: true };
     } catch (err: unknown) {
-      this.options.onLog('error', `Error executing step ${step.step_id}`, err instanceof Error ? err.message : String(err));
+      this.options.onLog(
+        'error',
+        `Error executing step ${step.step_id}`,
+        err instanceof Error ? err.message : String(err)
+      );
 
       this.options.onStepExecutionComplete?.({
         stepId: step.step_id,
@@ -275,31 +333,34 @@ export class FlowRunner {
       return;
     }
 
-    this.options.onLog('debug', `Resetting data for step ${step.step_id}`, 
-      `Clearing ${step.endpoints.length} endpoint(s) data`);
+    this.options.onLog(
+      'debug',
+      `Resetting data for step ${step.step_id}`,
+      `Clearing ${step.endpoints.length} endpoint(s) data`
+    );
 
     // Reset data for each endpoint in the step
     step.endpoints.forEach((endpoint, index) => {
       const endpointId = `${step.step_id}-${index}`;
-      
+
       // Clear stored response
       if (this.state.storedResponses[endpointId]) {
         delete this.state.storedResponses[endpointId];
         this.options.onLog('debug', `Cleared stored response for ${endpointId}`);
       }
-      
+
       // Clear stored transformations
       if (this.state.storedTransformations[endpointId]) {
         delete this.state.storedTransformations[endpointId];
         this.options.onLog('debug', `Cleared stored transformations for ${endpointId}`);
       }
-      
+
       // Clear execution state
       if (this.state.executionState[endpointId]) {
         delete this.state.executionState[endpointId];
         this.options.onLog('debug', `Cleared execution state for ${endpointId}`);
       }
-      
+
       // Clear cookies for this endpoint
       if (this.state.cookieStore.has(endpointId)) {
         this.state.cookieStore.delete(endpointId);
@@ -307,11 +368,38 @@ export class FlowRunner {
       }
     });
 
-    // Additionally, if the step has clearCookiesBeforeExecution flag, 
+    // Additionally, if the step has clearCookiesBeforeExecution flag,
     // we respect it by clearing all cookies (the execution engine will handle this)
     if (step.clearCookiesBeforeExecution === true) {
-      this.options.onLog('debug', `Step ${step.step_id} has clearCookiesBeforeExecution flag - all cookies will be cleared during execution`);
+      this.options.onLog(
+        'debug',
+        `Step ${step.step_id} has clearCookiesBeforeExecution flag - all cookies will be cleared during execution`
+      );
     }
+  }
+
+  hydrateExecutionSnapshot(
+    executionState: ExecutionState,
+    parameterValues: Record<string, unknown> = {}
+  ): void {
+    this.replaceRecord(this.state.executionState, executionState);
+    this.replaceRecord(
+      this.state.storedResponses,
+      this.extractResponsesFromExecutionState(executionState)
+    );
+    this.replaceRecord(
+      this.state.storedTransformations,
+      this.extractTransformationsFromExecutionState(executionState)
+    );
+    this.state.parameterValues = { ...parameterValues };
+    this.state.currentStep = executionState.currentStep || 0;
+    this.state.progress = executionState.progress || 0;
+    this.state.error = null;
+    this.state.isRunning = false;
+    this.state.shouldStopExecution = false;
+    this.state.cookieStore.clear();
+    this.setupManagers();
+    this.options.onExecutionStateUpdate(this.state.executionState);
   }
 
   stopExecution(): void {
@@ -325,21 +413,22 @@ export class FlowRunner {
     this.state.currentStep = 0;
     this.state.progress = 0;
     this.state.error = null;
-    this.state.storedResponses = {};
-    this.state.storedTransformations = {};
-    this.state.executionState = {};
+    this.clearRecord(this.state.storedResponses);
+    this.clearRecord(this.state.storedTransformations);
+    this.clearRecord(this.state.executionState);
     this.state.isRunning = false;
     this.state.parameterValues = {};
     this.state.shouldStopExecution = false;
     this.state.cookieStore.clear();
+    this.setupManagers();
   }
 
   updateParameterValues(parametersWithMissingValues: FlowParameter[]): void {
     this.state.parameterValues = this.parameterManager.updateParameterValues(
-      parametersWithMissingValues, 
+      parametersWithMissingValues,
       this.state.parameterValues
     );
-    
+
     // Update execution context with new parameter values
     this.executionEngine.updateParameterValues(this.state.parameterValues);
   }
@@ -349,28 +438,32 @@ export class FlowRunner {
    */
   setParameterValues(parameterValues: Record<string, unknown>): void {
     this.state.parameterValues = { ...parameterValues };
-    
+
     // Update execution context with new parameter values
     this.executionEngine.updateParameterValues(this.state.parameterValues);
   }
 
-  private updateExecutionState(endpointId: string, updates: Partial<any>, emitEndpointUpdate: boolean = false): void {
+  private updateExecutionState(
+    endpointId: string,
+    updates: Partial<ExecutionState[string]>,
+    emitEndpointUpdate: boolean = false
+  ): void {
     const updatedEndpointState = {
       ...this.state.executionState[endpointId],
       ...updates
     };
-    
+
     this.state.executionState = {
       ...this.state.executionState,
       [endpointId]: updatedEndpointState
     };
-    
+
     // Update progress and current step in execution state
     this.state.executionState.progress = this.state.progress;
     this.state.executionState.currentStep = this.state.currentStep;
-    
+
     this.options.onExecutionStateUpdate(this.state.executionState);
-    
+
     if (emitEndpointUpdate) {
       this.options.onEndpointStateUpdate({
         endpointId,
@@ -379,12 +472,78 @@ export class FlowRunner {
     }
   }
 
+  private clearRecord(record: Record<string, unknown>): void {
+    Object.keys(record).forEach((key) => {
+      delete record[key];
+    });
+  }
+
+  private replaceRecord<T>(target: Record<string, T>, source: Record<string, T>): void {
+    Object.keys(target).forEach((key) => {
+      delete target[key];
+    });
+    Object.assign(target, source);
+  }
+
+  private extractResponsesFromExecutionState(
+    executionState: ExecutionState
+  ): Record<string, unknown> {
+    const responses: Record<string, unknown> = {};
+    Object.entries(executionState).forEach(([endpointId, state]) => {
+      if (
+        typeof state === 'object' &&
+        state !== null &&
+        'response' in state &&
+        state.response?.body
+      ) {
+        responses[endpointId] = state.response.body;
+      }
+    });
+
+    return responses;
+  }
+
+  private extractTransformationsFromExecutionState(
+    executionState: ExecutionState
+  ): Record<string, Record<string, unknown>> {
+    const transformations: Record<string, Record<string, unknown>> = {};
+    Object.entries(executionState).forEach(([endpointId, state]) => {
+      if (
+        typeof state === 'object' &&
+        state !== null &&
+        'transformations' in state &&
+        state.transformations
+      ) {
+        transformations[endpointId] = state.transformations;
+      }
+    });
+
+    return transformations;
+  }
+
   // Getters for state access
-  get isRunning(): boolean { return this.state.isRunning; }
-  get currentStep(): number { return this.state.currentStep; }
-  get progress(): number { return this.state.progress; }
-  get error(): unknown { return this.state.error; }
-  get executionState(): ExecutionState { return this.state.executionState; }
-  get parameterValues(): Record<string, unknown> { return this.state.parameterValues; }
-  get storedResponses(): Record<string, unknown> { return this.state.storedResponses; }
+  get isRunning(): boolean {
+    return this.state.isRunning;
+  }
+  get currentStep(): number {
+    return this.state.currentStep;
+  }
+  get progress(): number {
+    return this.state.progress;
+  }
+  get error(): unknown {
+    return this.state.error;
+  }
+  get executionState(): ExecutionState {
+    return this.state.executionState;
+  }
+  get parameterValues(): Record<string, unknown> {
+    return this.state.parameterValues;
+  }
+  get storedResponses(): Record<string, unknown> {
+    return this.state.storedResponses;
+  }
+  get storedTransformations(): Record<string, Record<string, unknown>> {
+    return this.state.storedTransformations;
+  }
 }

--- a/src/lib/store/test-flow-run-cache.test.ts
+++ b/src/lib/store/test-flow-run-cache.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createFlowSignature,
+  loadRunSnapshot,
+  sanitizeExecutionState,
+  saveRunSnapshot
+} from './test-flow-run-cache';
+import type { ExecutionState, TestFlowData } from '$lib/components/test-flows/types';
+
+const flowData: TestFlowData = {
+  settings: {
+    api_hosts: {
+      1: { url: 'https://api.example.com' }
+    },
+    environment: {
+      environmentId: 1,
+      subEnvironment: 'dev'
+    }
+  },
+  parameters: [],
+  outputs: [],
+  steps: [
+    {
+      step_id: 'step-1',
+      label: 'Step 1',
+      endpoints: [
+        {
+          endpoint_id: 1,
+          api_id: 1,
+          headers: [{ name: 'Authorization', value: 'Bearer token', enabled: true }]
+        }
+      ]
+    }
+  ]
+};
+
+function installLocalStorageMock() {
+  const storage = new Map<string, string>();
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
+      removeItem: vi.fn((key: string) => storage.delete(key))
+    }
+  });
+}
+
+describe('test flow run cache', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    installLocalStorageMock();
+  });
+
+  it('saves and loads successful snapshots for unchanged flow data', () => {
+    const executionState = {
+      'step-1-0': {
+        status: 'completed',
+        request: {
+          url: 'https://api.example.com/users',
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer secret',
+            Accept: 'application/json'
+          }
+        },
+        response: {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'set-cookie': 'session=secret'
+          },
+          body: { id: 1 }
+        },
+        transformations: { userId: 1 }
+      },
+      progress: 100,
+      currentStep: 0
+    } as ExecutionState;
+
+    expect(
+      saveRunSnapshot({
+        testFlowId: 123,
+        flowData,
+        executionState,
+        parameterValues: { userId: 1 },
+        flowOutputs: { createdUserId: 1 }
+      })
+    ).toBe(true);
+
+    const snapshot = loadRunSnapshot(123, flowData);
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.executionState['step-1-0']?.response?.body).toEqual({ id: 1 });
+    expect(snapshot?.executionState['step-1-0']?.request?.headers?.Authorization).toBe(
+      '[redacted]'
+    );
+    expect(snapshot?.executionState['step-1-0']?.response?.headers?.['set-cookie']).toBe(
+      '[redacted]'
+    );
+    expect(snapshot?.flowOutputs).toEqual({ createdUserId: 1 });
+  });
+
+  it('ignores snapshots when the flow signature no longer matches', () => {
+    saveRunSnapshot({
+      testFlowId: 123,
+      flowData,
+      executionState: {},
+      parameterValues: {}
+    });
+
+    const changedFlowData: TestFlowData = {
+      ...flowData,
+      steps: [...flowData.steps, { step_id: 'step-2', label: 'Step 2', endpoints: [] }]
+    };
+
+    expect(loadRunSnapshot(123, changedFlowData)).toBeNull();
+  });
+
+  it('creates stable signatures regardless of object key insertion order', () => {
+    const reorderedFlowData: TestFlowData = {
+      ...flowData,
+      settings: {
+        environment: flowData.settings.environment,
+        api_hosts: flowData.settings.api_hosts
+      }
+    };
+
+    expect(createFlowSignature(reorderedFlowData)).toBe(createFlowSignature(flowData));
+  });
+
+  it('redacts sensitive request and response headers from execution state', () => {
+    const sanitized = sanitizeExecutionState({
+      'step-1-0': {
+        request: {
+          headers: {
+            authorization: 'Bearer secret',
+            Cookie: 'session=secret',
+            Accept: 'application/json'
+          }
+        },
+        response: {
+          headers: {
+            'Set-Cookie': 'session=secret',
+            'Content-Type': 'application/json'
+          }
+        }
+      }
+    });
+
+    expect(sanitized['step-1-0']?.request?.headers?.authorization).toBe('[redacted]');
+    expect(sanitized['step-1-0']?.request?.headers?.Cookie).toBe('[redacted]');
+    expect(sanitized['step-1-0']?.request?.headers?.Accept).toBe('application/json');
+    expect(sanitized['step-1-0']?.response?.headers?.['Set-Cookie']).toBe('[redacted]');
+    expect(sanitized['step-1-0']?.response?.headers?.['Content-Type']).toBe('application/json');
+  });
+});

--- a/src/lib/store/test-flow-run-cache.ts
+++ b/src/lib/store/test-flow-run-cache.ts
@@ -1,0 +1,234 @@
+import type { ExecutionState, TestFlowData } from '$lib/components/test-flows/types';
+
+const CACHE_VERSION = 1;
+const CACHE_KEY_PREFIX = 'test-pilot:test-flow-run-cache:';
+const MAX_SNAPSHOT_BYTES = 4 * 1024 * 1024;
+const REDACTED_VALUE = '[redacted]';
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'proxy-authorization'
+]);
+
+type JsonRecord = Record<string, unknown>;
+
+export interface TestFlowRunSnapshot {
+  version: number;
+  testFlowId: string;
+  flowSignature: string;
+  cachedAt: string;
+  runId: string;
+  status: 'success';
+  executionState: ExecutionState;
+  parameterValues: Record<string, unknown>;
+  flowOutputs: Record<string, unknown>;
+}
+
+export interface SaveRunSnapshotInput {
+  testFlowId: string | number | undefined;
+  flowData: TestFlowData;
+  executionState: ExecutionState;
+  parameterValues: Record<string, unknown>;
+  flowOutputs?: Record<string, unknown>;
+}
+
+export function createFlowSignature(flowData: TestFlowData): string {
+  return hashString(
+    stableStringify({
+      settings: flowData.settings,
+      parameters: flowData.parameters,
+      outputs: flowData.outputs ?? [],
+      steps: flowData.steps
+    })
+  );
+}
+
+export function loadRunSnapshot(
+  testFlowId: string | number | undefined,
+  flowData: TestFlowData
+): TestFlowRunSnapshot | null {
+  const storage = getStorage();
+  const normalizedTestFlowId = normalizeTestFlowId(testFlowId);
+  if (!storage || !normalizedTestFlowId) return null;
+
+  try {
+    const rawSnapshot = storage.getItem(getCacheKey(normalizedTestFlowId));
+    if (!rawSnapshot) return null;
+
+    const snapshot = JSON.parse(rawSnapshot) as TestFlowRunSnapshot;
+    if (!isValidSnapshot(snapshot, normalizedTestFlowId)) return null;
+
+    if (snapshot.flowSignature !== createFlowSignature(flowData)) {
+      return null;
+    }
+
+    return snapshot;
+  } catch (error) {
+    console.warn('Failed to load test flow run snapshot from localStorage:', error);
+    return null;
+  }
+}
+
+export function saveRunSnapshot(input: SaveRunSnapshotInput): boolean {
+  const storage = getStorage();
+  const normalizedTestFlowId = normalizeTestFlowId(input.testFlowId);
+  if (!storage || !normalizedTestFlowId) return false;
+
+  const snapshot: TestFlowRunSnapshot = {
+    version: CACHE_VERSION,
+    testFlowId: normalizedTestFlowId,
+    flowSignature: createFlowSignature(input.flowData),
+    cachedAt: new Date().toISOString(),
+    runId: createRunId(),
+    status: 'success',
+    executionState: sanitizeExecutionState(input.executionState),
+    parameterValues: sanitizeValue(input.parameterValues) as Record<string, unknown>,
+    flowOutputs: sanitizeValue(input.flowOutputs ?? {}) as Record<string, unknown>
+  };
+
+  try {
+    const serializedSnapshot = JSON.stringify(snapshot);
+    if (byteLength(serializedSnapshot) > MAX_SNAPSHOT_BYTES) {
+      console.warn(
+        'Skipping test flow run snapshot cache because it exceeds localStorage size budget.'
+      );
+      return false;
+    }
+
+    storage.setItem(getCacheKey(normalizedTestFlowId), serializedSnapshot);
+    return true;
+  } catch (error) {
+    console.warn('Failed to save test flow run snapshot to localStorage:', error);
+    return false;
+  }
+}
+
+export function clearRunSnapshot(testFlowId: string | number | undefined): void {
+  const storage = getStorage();
+  const normalizedTestFlowId = normalizeTestFlowId(testFlowId);
+  if (!storage || !normalizedTestFlowId) return;
+
+  try {
+    storage.removeItem(getCacheKey(normalizedTestFlowId));
+  } catch (error) {
+    console.warn('Failed to clear test flow run snapshot from localStorage:', error);
+  }
+}
+
+export function sanitizeExecutionState(executionState: ExecutionState): ExecutionState {
+  return sanitizeValue(executionState, { parentKey: 'executionState' }) as ExecutionState;
+}
+
+function sanitizeValue(
+  value: unknown,
+  context: { parentKey?: string; key?: string } = {}
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, context));
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const sanitized: JsonRecord = {};
+  for (const [key, childValue] of Object.entries(value)) {
+    const isHeadersObject = key === 'headers' && isPlainObject(childValue);
+    if (isHeadersObject) {
+      sanitized[key] = sanitizeHeaders(childValue as Record<string, unknown>);
+    } else if (isSensitiveHeaderName(context.parentKey, key)) {
+      sanitized[key] = REDACTED_VALUE;
+    } else {
+      sanitized[key] = sanitizeValue(childValue, { parentKey: key, key });
+    }
+  }
+
+  return sanitized;
+}
+
+function sanitizeHeaders(headers: Record<string, unknown>): Record<string, unknown> {
+  const sanitizedHeaders: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    sanitizedHeaders[name] = isSensitiveHeaderName('headers', name) ? REDACTED_VALUE : value;
+  }
+
+  return sanitizedHeaders;
+}
+
+function isSensitiveHeaderName(parentKey: string | undefined, key: string): boolean {
+  return parentKey === 'headers' && SENSITIVE_HEADER_NAMES.has(key.toLowerCase());
+}
+
+function isValidSnapshot(snapshot: TestFlowRunSnapshot, testFlowId: string): boolean {
+  return (
+    snapshot?.version === CACHE_VERSION &&
+    snapshot.testFlowId === testFlowId &&
+    snapshot.status === 'success' &&
+    typeof snapshot.flowSignature === 'string' &&
+    typeof snapshot.cachedAt === 'string' &&
+    isPlainObject(snapshot.executionState) &&
+    isPlainObject(snapshot.parameterValues) &&
+    isPlainObject(snapshot.flowOutputs)
+  );
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  return window.localStorage;
+}
+
+function normalizeTestFlowId(testFlowId: string | number | undefined): string | null {
+  if (testFlowId === undefined || testFlowId === null || testFlowId === '') return null;
+  return String(testFlowId);
+}
+
+function getCacheKey(testFlowId: string): string {
+  return `${CACHE_KEY_PREFIX}${testFlowId}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify((value as JsonRecord)[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function hashString(value: string): string {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(i);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
+function createRunId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function byteLength(value: string): number {
+  if (typeof Blob !== 'undefined') {
+    return new Blob([value]).size;
+  }
+
+  return value.length;
+}
+
+function isPlainObject(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
### Motivation
- Preserve transient execution results so previews (expression/transform/assertion previews) survive tab unmount/remount and page navigation.
- Provide a safe, size-limited local cache of the last successful run so users can restore execution-driven UI state without re-running requests.
- Avoid leaking sensitive values by redacting known sensitive headers before persisting snapshots.

### Description
- Add a client-side snapshot cache at `src/lib/store/test-flow-run-cache.ts` that saves versioned `TestFlowRunSnapshot` objects to `localStorage` with a stable `flowSignature`, a 4MB size guardrail, and header redaction. (`createFlowSignature`, `saveRunSnapshot`, `loadRunSnapshot`, `clearRunSnapshot`).
- Wire the editor to hydrate and persist snapshots by importing `loadRunSnapshot`, `saveRunSnapshot`, and `clearRunSnapshot` in `src/lib/components/test-flows/TestFlowEditor.svelte`, calling `hydrateCachedRunSnapshot` on runner initialization, saving only after a successful run, and clearing on user reset.
- Extend `FlowRunner` (`src/lib/flow-runner/flow-runner.ts`) to expose and preserve `storedResponses`, `storedTransformations`, and `executionState`, add `hydrateExecutionSnapshot` to restore runner state, and add helpers to replace/clear internal records so manager references remain consistent after hydration/reset.
- Add unit tests for the cache in `src/lib/store/test-flow-run-cache.test.ts` that validate save/load behavior, stale-signature rejection, stable signature generation, and header redaction.

### Testing
- Ran unit tests: `npm run test:unit -- --run src/lib/store/test-flow-run-cache.test.ts` and all tests passed (4 tests). 
- Ran type checks: `npm run check` which surfaced unrelated existing typing issues in `src/lib/server/middleware/auth.ts` (`$env/static/private` missing `JWT_SECRET`/`JWT_EXPIRY`), so full `svelte-check` did not finish cleanly. 
- Ran formatting/lint checks: `npm run lint` (Prettier/ESLint) — repository-wide Prettier baseline warnings remain unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20030ff8bc832694d7074d666d6761)